### PR TITLE
Swagger categories

### DIFF
--- a/src/compojure_swagger/core.clj
+++ b/src/compojure_swagger/core.clj
@@ -34,6 +34,11 @@
 (defn with-swagger [route swagger]
   (assoc route :swagger swagger))
 
+(defn swagger-categories [route category-names]
+  (if (:children route)
+    (assoc route :children (map #(swagger-categories % category-names) (:children route)))
+    (update-in route [:swagger :swagger-content :tags] #(apply conj %1 %2) category-names)))
+
 (defn swagger-category [route category-name]
   (if (:children route)
     (assoc route :children (map #(swagger-category % category-name) (:children route)))

--- a/test/compojure_swagger/core_test.clj
+++ b/test/compojure_swagger/core_test.clj
@@ -125,6 +125,19 @@
     (testing "swagify-verb swagifies verbs as expected"
       (is (= (swagify-verb handler) expected-swagger)))))
 
+(deftest swagger-category-swagify-test
+  (testing "swagger-category assigns tag as expected"
+    (let [handler (core/swagger-category (core/context "/model_trains" []
+                                                        (core/with-swagger
+                                                          (core/POST "/test1/:id" [])
+                                                          {:swagger-content {:summary "it works"}})
+                                                        (core/GET "/test2" []))
+                                          "model trains")
+          expected-swagger {"/model_trains/test1/:id" {:post {:summary    "it works",
+                                                              :tags ["model trains"]}}
+                            "/model_trains/test2" {:get {:tags ["model trains"]}}}]
+      (is (= (swagify-route handler) expected-swagger)))))
+
 (deftest with-swagger-get-test
   (testing "with-swagger doesn't create a required body when none is specified"
     (let [handler (core/with-swagger (core/GET "/test1" [])

--- a/test/compojure_swagger/core_test.clj
+++ b/test/compojure_swagger/core_test.clj
@@ -134,8 +134,21 @@
                                                         (core/GET "/test2" []))
                                           "model trains")
           expected-swagger {"/model_trains/test1/:id" {:post {:summary    "it works",
-                                                              :tags ["model trains"]}}
-                            "/model_trains/test2" {:get {:tags ["model trains"]}}}]
+                                                              :tags '("model trains")}}
+                            "/model_trains/test2" {:get {:tags '("model trains")}}}]
+      (is (= (swagify-route handler) expected-swagger)))))
+
+(deftest swagger-categories-swagify-test
+  (testing "swagger-categories (plural) assigns tags as expected"
+    (let [handler (core/swagger-categories (core/context "/model_trains" []
+                                                        (core/with-swagger
+                                                          (core/POST "/test1/:id" [])
+                                                          {:swagger-content {:summary "it works"}})
+                                                        (core/GET "/test2" []))
+                                          ["model trains" "stamp collecting"])
+          expected-swagger {"/model_trains/test1/:id" {:post {:summary    "it works",
+                                                              :tags '("stamp collecting" "model trains")}}
+                            "/model_trains/test2" {:get {:tags '("stamp collecting" "model trains")}}}]
       (is (= (swagify-route handler) expected-swagger)))))
 
 (deftest with-swagger-get-test


### PR DESCRIPTION
This PR adds swagger-category and swagger-categories for setting one or multiple tags for all children of a context. Useful for grouping the API.
It's debatable whether swagger-category and swagger-categories should be two separate functions.
Resolves #3.