### PR TITLE
Add Support for Arbitrary Filtering of JSON Swagger Responses

### DIFF
--- a/src/compojure_swagger/core.clj
+++ b/src/compojure_swagger/core.clj
@@ -159,6 +159,7 @@
     (cc/GET "/swagger.json" {}
       (resource :available-media-types ["application/json"]
                 :handle-ok
-                (swagger-spec
-                  (rsc/deep-merge swagger-default (:swagger-options options))
-                  swag-routes)))))
+                ((or (:route-filter options) identity)
+                 (swagger-spec
+                   (rsc/deep-merge swagger-default (:swagger-options options))
+                   swag-routes))))))


### PR DESCRIPTION
Add an optional argument that allows filtering of the JSON response
given to the swagger UI. This allows control over display of swagger
endpoints based on arbitrary metadata.