### PR TITLE
Allow Filter Function to Compute Over Request

### DIFF
--- a/src/compojure_swagger/core.clj
+++ b/src/compojure_swagger/core.clj
@@ -156,10 +156,11 @@
   (cc/routes
     swag-routes
     (ui/swagger-ui (:meta-options options))
-    (cc/GET "/swagger.json" {}
+    (cc/GET "/swagger.json" req
       (resource :available-media-types ["application/json"]
                 :handle-ok
-                ((or (:route-filter options) identity)
+                ((or (:route-filter options) (fn [_ resp] resp))
+                 req
                  (swagger-spec
                    (rsc/deep-merge swagger-default (:swagger-options options))
                    swag-routes))))))

--- a/test/compojure_swagger/core_test.clj
+++ b/test/compojure_swagger/core_test.clj
@@ -131,7 +131,7 @@
   (s/def ::id int?)
   (let [id-spec (s/keys :req [::id])
         test-spec (s/keys :req [::first-name] :opt [::last-name])
-        privatize-filter (fn [data]
+        privatize-filter (fn [req data]
                            (update data :paths (partial
                                                 map
                                                 (fn [[path method-map]]


### PR DESCRIPTION
Currently the request was not matched against, which made
it hard to do a filter based on request state. Add support for this.